### PR TITLE
ci: add clippy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,4 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       - run: cargo test
+      - run: cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
adds clippy to CI

(`--all-features` is redundant, but future-proof - let me know if that should be dropped :+1:)